### PR TITLE
Cleanup cleaner template

### DIFF
--- a/lib/squasher/templates/squasher_clean.rb.erb
+++ b/lib/squasher/templates/squasher_clean.rb.erb
@@ -3,8 +3,8 @@ class SquasherClean < ActiveRecord::Migration
   end
 
   def up
-    migrations = Dir.glob(File.join(File.dirname(__FILE__), '**.rb'))
-    versions = migrations.map { |file| file.split('/').last[/\A\d+/] }
+    migrations = Dir.glob(File.join(File.dirname(__FILE__), '*.rb'))
+    versions = migrations.map { |file| File.basename(file)[/\A\d+/] }
     SchemaMigration.where("version NOT IN (?)", versions).delete_all
   end
 


### PR DESCRIPTION
This pull request fixes a couple of minor issues in the schema migration table cleaner template.

1. Removes an extraneous `*` from the glob pattern for matching migration files.
2. Replaces the code for extracting a migration's file name from its path with a platform-agnostic method.