### PR TITLE
Don't suppress stderr from rake tasks

### DIFF
--- a/lib/squasher.rb
+++ b/lib/squasher.rb
@@ -18,7 +18,7 @@ module Squasher
 
   def rake(command, description = nil)
     tell(description) if description
-    system("bundle exec rake #{ command } 2>/dev/null")
+    system("bundle exec rake #{ command }")
   end
 
   def ask(*args)


### PR DESCRIPTION
This fixes #16.

The change was added in #14, though I'm not quite sure why. Hiding stderr output should have no effect on what `system` returns.