### PR TITLE
Use `ActiveRecord::IrreversibleMigration` in template

### DIFF
--- a/lib/squasher/templates/init_schema.rb.erb
+++ b/lib/squasher/templates/init_schema.rb.erb
@@ -6,6 +6,6 @@ class InitSchema < ActiveRecord::Migration
   end
 
   def down
-    raise "Can not revert initial migration"
+    raise ActiveRecord::IrreversibleMigration, "Cannot revert initial migration"
   end
 end


### PR DESCRIPTION
For semantic-ness and correct exception handling, the `down` can use an `ActiveRecord::IrreversibleMigration`. Hope this is useful!