### PR TITLE
Support Rails engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,16 @@ process breaks in a migration from 2014. In this situation you squash till 2014,
 database at the end, make a patch in the broken migration and run again the suite with `-r` option. As the result
 squasher will not need to create the db schema and all data from the previous migrations will be there.
 
+`-e` - tell squasher that you are squashing a Rails engine. You must execute squasher from within the engine's dummy app (ex., `[root]/spec/dummy`) otherwise it will fail. This option is necessary, otherwise squasher will fail to discover schema.rb and database.yml as these are not part of an engine, but of a regular Rails application.
+
 ## Requirements
 
 It works and was tested on Ruby 2.0+ and Rails 3.1+. It also requires a valid development configuration in `config/database.yml` and using Ruby format in `db/schema.rb` (default Rails use-case).
 If an old migration inserted data (created ActiveRecord model records) you will lose this code in the squashed migration, **BUT** `squasher` will ask you to leave a tmp database which will have all data that was inserted while migrating. Using this database you could add that data as another migration, or into `config/seed.rb` (the expected place for this stuff).
 
 ## Changelog
+- 0.2.3
+  - support rails engines
 - 0.2.2
   - strip white spaces in init migrations
 - 0.2.1

--- a/lib/squasher/config.rb
+++ b/lib/squasher/config.rb
@@ -7,11 +7,11 @@ module Squasher
     attr_reader :schema_file
 
     def initialize
-      root_path = Dir.pwd
+      app_path = Squasher.app_path || Dir.pwd
 
-      @schema_file = File.join(root_path, 'db', 'schema.rb')
-      @migrations_folder = File.join(root_path, 'db', 'migrate')
-      @dbconfig_file = File.join(root_path, 'config', 'database.yml')
+      @schema_file = File.join(app_path, 'db', 'schema.rb')
+      @migrations_folder = File.join(Squasher.root_path || app_path, 'db', 'migrate')
+      @dbconfig_file = File.join(app_path, 'config', 'database.yml')
     end
 
     def migration_files

--- a/lib/squasher/worker.rb
+++ b/lib/squasher/worker.rb
@@ -2,7 +2,7 @@ require 'fileutils'
 
 module Squasher
   class Worker
-    OPTIONS = [:d, :r]
+    OPTIONS = [:d, :r, :e]
 
     attr_reader :date, :options
 
@@ -50,9 +50,7 @@ module Squasher
     end
 
     def migrations
-      return @migrations if @migrations
-
-      @migrations = config.migration_files.select { |file| before_date?(get_timestamp(file)) }.sort
+      @migrations ||= config.migration_files.select { |file| before_date?(get_timestamp(file)) }.sort
     end
 
     def get_timestamp(file)

--- a/squasher.gemspec
+++ b/squasher.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "squasher"
-  spec.version       = "0.2.2"
+  spec.version       = "0.2.3"
   spec.authors       = ["Sergey Pchelintsev"]
   spec.email         = ["mail@sergeyp.me"]
   spec.description   = %q{Squash your old migrations}


### PR DESCRIPTION
Added `-e` argument to let squasher know we're running inside an engine. The squasher command must be run from within the dummy app directory, not the real root. Otherwise there's no way to accurately tell where the dummy app resides. This at the very least assumes the actual engine's root is a parent directory of the dummy directory which is a fairly safe assumption.

Perhaps in the future it would be good to let the user specify the relative/absolute directory of the engine if need be right after the `-e` argument.