### PR TITLE
Fix squasher clean

### DIFF
--- a/lib/squasher/worker.rb
+++ b/lib/squasher/worker.rb
@@ -28,7 +28,7 @@ module Squasher
         Squasher.rake("db:drop") unless Squasher.ask(:keep_database)
       end
 
-      Squasher.clean if result && Squasher.ask(:apply_clean)
+      Squasher.clean({}) if result && Squasher.ask(:apply_clean)
     end
 
     private

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,4 +21,8 @@ Bundler.require
 RSpec.configure do |config|
   config.order = 'random'
   config.include SpecHelpers
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
 end


### PR DESCRIPTION
This pull request enables Rspec's method / argument existence checks and fixes Squasher::Worker#process calling Squasher.clean without required argument.