### PR TITLE
Support init schema from structure sql

### DIFF
--- a/bin/squasher
+++ b/bin/squasher
@@ -20,6 +20,10 @@ parser = OptionParser.new do |config|
     options[:engine] = nil
   end
 
+  config.on('-s', '--structure') do
+    options[:structure] = true
+  end
+
   config.on('--engine=PATH') do |value|
     options[:engine] = value
   end

--- a/bin/squasher
+++ b/bin/squasher
@@ -20,8 +20,8 @@ parser = OptionParser.new do |config|
     options[:engine] = nil
   end
 
-  config.on('-s', '--structure') do
-    options[:structure] = true
+  config.on('-s', '--sql') do
+    options[:sql] = true
   end
 
   config.on('--engine=PATH') do |value|

--- a/lib/squasher/config.rb
+++ b/lib/squasher/config.rb
@@ -57,7 +57,7 @@ module Squasher
       elsif key == :migration
         Squasher.error(:invalid_migration_version, value: value) unless value.to_s =~ /\A\d.\d\z/
         @migration_version = "[#{value}]"
-      elsif key == :structure
+      elsif key == :sql
         @schema_file = File.join(@app_path, 'db', 'structure.sql')
         @flags << key
       else

--- a/lib/squasher/config.rb
+++ b/lib/squasher/config.rb
@@ -57,6 +57,9 @@ module Squasher
       elsif key == :migration
         Squasher.error(:invalid_migration_version, value: value) unless value.to_s =~ /\A\d.\d\z/
         @migration_version = "[#{value}]"
+      elsif key == :structure
+        @schema_file = File.join(@app_path, 'db', 'structure.sql')
+        @flags << key
       else
         @flags << key
       end

--- a/lib/squasher/render.rb
+++ b/lib/squasher/render.rb
@@ -19,7 +19,7 @@ module Squasher
 
     def each_schema_line(&block)
       File.open(config.schema_file, 'r') do |stream|
-        if @config.set?(:structure)
+        if @config.set?(:sql)
           stream_structure(stream, &block)
         else
           stream_schema(stream, &block)
@@ -41,7 +41,7 @@ module Squasher
           next
         end
 
-        yield line
+        yield line.gsub(/\A\s{,2}(.*)\s+\z/, '\1')
       end
       yield 'SQL'
     end

--- a/lib/squasher/render.rb
+++ b/lib/squasher/render.rb
@@ -31,13 +31,13 @@ module Squasher
 
     def stream_structure(stream)
       yield 'execute <<-SQL'
-      insert_migration = false
+      skip_mode = false
       ignored_table = ['ar_internal_metadata', 'schema_migrations']
       stream.each_line do |line|
-        insert_migration = true if ignored_table.any? { |t| line.include?(t) }
+        skip_mode = true if ignored_table.any? { |t| line.include?(t) }
 
-        if insert_migration
-          insert_migration = false if line.include?(';')
+        if skip_mode
+          skip_mode = false if line.include?(';')
           next
         end
 

--- a/lib/squasher/templates/init_schema.rb.erb
+++ b/lib/squasher/templates/init_schema.rb.erb
@@ -1,7 +1,8 @@
 class InitSchema < ActiveRecord::Migration<%= @config.migration_version %>
   def up
 <%- each_schema_line do |line| -%>
-<%= line.strip.empty? ? '' : "    #{line}" %>
+<%- next if line.strip.empty?  -%>
+<%= "    #{line}" %>
 <%- end -%>
   end
 

--- a/spec/fake_app/db/structure.sql
+++ b/spec/fake_app/db/structure.sql
@@ -13,7 +13,6 @@ CREATE TABLE managers (
     updated_at timestamp without time zone NOT NULL
 );
 
-
 CREATE TABLE offices (
     id integer NOT NULL,
     name character varying,
@@ -47,4 +46,3 @@ ALTER TABLE ONLY schema_migrations
 INSERT INTO "schema_migrations" (version) VALUES
 ('20170831152134'),
 ('20170907145259');
-

--- a/spec/fake_app/db/structure.sql
+++ b/spec/fake_app/db/structure.sql
@@ -26,3 +26,25 @@ CREATE TABLE offices (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
 );
+
+CREATE TABLE ar_internal_metadata (
+    key character varying NOT NULL,
+    value character varying,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+CREATE TABLE schema_migrations (
+    version character varying NOT NULL
+);
+
+ALTER TABLE ONLY ar_internal_metadata
+    ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
+
+ALTER TABLE ONLY schema_migrations
+    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+INSERT INTO "schema_migrations" (version) VALUES
+('20170831152134'),
+('20170907145259');
+

--- a/spec/fake_app/db/structure.sql
+++ b/spec/fake_app/db/structure.sql
@@ -1,0 +1,28 @@
+CREATE TABLE cities (
+    id integer NOT NULL,
+    name character varying,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+);
+
+CREATE TABLE managers (
+    id integer NOT NULL,
+    email character varying,
+    password_digest character varying,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+CREATE TABLE offices (
+    id integer NOT NULL,
+    name character varying,
+    address character varying,
+    phone character varying,
+    description text,
+    capacity integer,
+    manager_id integer,
+    city_id integer,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);

--- a/spec/lib/worker_spec.rb
+++ b/spec/lib/worker_spec.rb
@@ -55,8 +55,8 @@ describe Squasher::Worker do
       Squasher.instance_variable_set(:@config, Squasher::Config.new)
     end
 
-    specify 'the structure mode' do
-      Squasher.config.set(:structure, true)
+    specify 'the sql mode' do
+      Squasher.config.set(:sql, true)
       worker = described_class.new(Time.new(2014))
       allow(worker).to receive(:under_squash_env).and_yield.and_return(true)
       new_migration_path = File.join(Dir.tmpdir, 'init_schema.rb')
@@ -77,64 +77,30 @@ class InitSchema < ActiveRecord::Migration
   def up
     execute <<-SQL
     CREATE TABLE cities (
-
-        id integer NOT NULL,
-
-        name character varying,
-
-        created_at timestamp without time zone NOT NULL,
-
-        updated_at timestamp without time zone NOT NULL,
-
+      id integer NOT NULL,
+      name character varying,
+      created_at timestamp without time zone NOT NULL,
+      updated_at timestamp without time zone NOT NULL,
     );
-
-
     CREATE TABLE managers (
-
-        id integer NOT NULL,
-
-        email character varying,
-
-        password_digest character varying,
-
-        created_at timestamp without time zone NOT NULL,
-
-        updated_at timestamp without time zone NOT NULL
-
+      id integer NOT NULL,
+      email character varying,
+      password_digest character varying,
+      created_at timestamp without time zone NOT NULL,
+      updated_at timestamp without time zone NOT NULL
     );
-
-
-
     CREATE TABLE offices (
-
-        id integer NOT NULL,
-
-        name character varying,
-
-        address character varying,
-
-        phone character varying,
-
-        description text,
-
-        capacity integer,
-
-        manager_id integer,
-
-        city_id integer,
-
-        created_at timestamp without time zone NOT NULL,
-
-        updated_at timestamp without time zone NOT NULL
-
+      id integer NOT NULL,
+      name character varying,
+      address character varying,
+      phone character varying,
+      description text,
+      capacity integer,
+      manager_id integer,
+      city_id integer,
+      created_at timestamp without time zone NOT NULL,
+      updated_at timestamp without time zone NOT NULL
     );
-
-
-
-
-
-
-
     SQL
   end
 

--- a/spec/lib/worker_spec.rb
+++ b/spec/lib/worker_spec.rb
@@ -55,6 +55,34 @@ describe Squasher::Worker do
       Squasher.instance_variable_set(:@config, Squasher::Config.new)
     end
 
+    specify 'the structure mode' do
+      Squasher.config.set(:structure, true)
+      worker = described_class.new(Time.new(2014))
+      allow(worker).to receive(:under_squash_env).and_yield.and_return(true)
+      new_migration_path = File.join(Dir.tmpdir, 'init_schema.rb')
+      allow_any_instance_of(Squasher::Config).to receive(:migration_file).with('20131213090719', :init_schema).and_return(new_migration_path)
+      expect(FileUtils).to receive(:rm).with(File.join(fake_root, 'db', 'migrate', '20131205160936_first_migration.rb'))
+      expect(FileUtils).to receive(:rm).with(File.join(fake_root, 'db', 'migrate', '20131213090719_second_migration.rb'))
+
+      expect(Squasher).to receive(:ask).with(:keep_database).and_return(false)
+      expect(Squasher).to receive(:rake).with("db:drop")
+      expect(Squasher).to receive(:ask).with(:apply_clean).and_return(false)
+      worker.process
+
+      expect(File.exists?(new_migration_path)).to be_truthy
+      File.open(new_migration_path) do |stream|
+        content = stream.read
+        expect(content).to include("InitSchema")
+        expect(content).to include('execute <<-SQL')
+
+        File.open(File.join(Dir.pwd, 'spec', 'fake_app', 'db', 'structure.sql'), 'r') do |stream|
+          stream.each_line do |line|
+            expect(content).to include(line)
+          end
+        end
+      end
+    end
+
     specify 'the dry mode' do
       Squasher.config.set(:dry, nil)
       worker = described_class.new(Time.new(2014))

--- a/spec/lib/worker_spec.rb
+++ b/spec/lib/worker_spec.rb
@@ -72,14 +72,78 @@ describe Squasher::Worker do
       expect(File.exists?(new_migration_path)).to be_truthy
       File.open(new_migration_path) do |stream|
         content = stream.read
-        expect(content).to include("InitSchema")
-        expect(content).to include('execute <<-SQL')
+        expect(content).to eq(<<-RUBY
+class InitSchema < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+    CREATE TABLE cities (
 
-        File.open(File.join(Dir.pwd, 'spec', 'fake_app', 'db', 'structure.sql'), 'r') do |stream|
-          stream.each_line do |line|
-            expect(content).to include(line)
-          end
-        end
+        id integer NOT NULL,
+
+        name character varying,
+
+        created_at timestamp without time zone NOT NULL,
+
+        updated_at timestamp without time zone NOT NULL,
+
+    );
+
+
+    CREATE TABLE managers (
+
+        id integer NOT NULL,
+
+        email character varying,
+
+        password_digest character varying,
+
+        created_at timestamp without time zone NOT NULL,
+
+        updated_at timestamp without time zone NOT NULL
+
+    );
+
+
+
+    CREATE TABLE offices (
+
+        id integer NOT NULL,
+
+        name character varying,
+
+        address character varying,
+
+        phone character varying,
+
+        description text,
+
+        capacity integer,
+
+        manager_id integer,
+
+        city_id integer,
+
+        created_at timestamp without time zone NOT NULL,
+
+        updated_at timestamp without time zone NOT NULL
+
+    );
+
+
+
+
+
+
+
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "The initial migration is not revertable"
+  end
+end
+        RUBY
+      )
       end
     end
 


### PR DESCRIPTION
In order to support `sql` schema format, I added flag `-s` or `--structure` to generate init_schema migration from `structure.sql` instead of `schema.rb`