### PR TITLE
use %q notation in order to prevent regexp escapes

### DIFF
--- a/lib/squasher/render.rb
+++ b/lib/squasher/render.rb
@@ -30,7 +30,7 @@ module Squasher
     private
 
     def stream_structure(stream)
-      yield 'execute <<-SQL'
+      yield 'execute %q{'
       skip_mode = false
       ignored_table = ['ar_internal_metadata', 'schema_migrations']
       stream.each_line do |line|
@@ -43,7 +43,7 @@ module Squasher
 
         yield line.gsub(/\A\s{,2}(.*)\s+\z/, '\1')
       end
-      yield 'SQL'
+      yield '}'
     end
 
     def stream_schema(stream)

--- a/spec/fake_app/db/structure.sql
+++ b/spec/fake_app/db/structure.sql
@@ -10,7 +10,8 @@ CREATE TABLE managers (
     email character varying,
     password_digest character varying,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    CONSTRAINT email_format CHECK (email ~* '^.+@.+\..+')
 );
 
 CREATE TABLE offices (

--- a/spec/lib/worker_spec.rb
+++ b/spec/lib/worker_spec.rb
@@ -75,7 +75,7 @@ describe Squasher::Worker do
         expect(content).to eq(<<-RUBY
 class InitSchema < ActiveRecord::Migration
   def up
-    execute <<-SQL
+    execute %q{
     CREATE TABLE cities (
       id integer NOT NULL,
       name character varying,
@@ -101,7 +101,7 @@ class InitSchema < ActiveRecord::Migration
       created_at timestamp without time zone NOT NULL,
       updated_at timestamp without time zone NOT NULL
     );
-    SQL
+    }
   end
 
   def down

--- a/spec/lib/worker_spec.rb
+++ b/spec/lib/worker_spec.rb
@@ -72,7 +72,7 @@ describe Squasher::Worker do
       expect(File.exists?(new_migration_path)).to be_truthy
       File.open(new_migration_path) do |stream|
         content = stream.read
-        expect(content).to eq(<<-RUBY
+        expect(content.strip).to eq(%q{
 class InitSchema < ActiveRecord::Migration
   def up
     execute %q{
@@ -87,7 +87,8 @@ class InitSchema < ActiveRecord::Migration
       email character varying,
       password_digest character varying,
       created_at timestamp without time zone NOT NULL,
-      updated_at timestamp without time zone NOT NULL
+      updated_at timestamp without time zone NOT NULL,
+      CONSTRAINT email_format CHECK (email ~* '^.+@.+\..+')
     );
     CREATE TABLE offices (
       id integer NOT NULL,
@@ -108,7 +109,7 @@ class InitSchema < ActiveRecord::Migration
     raise ActiveRecord::IrreversibleMigration, "The initial migration is not revertable"
   end
 end
-        RUBY
+        }.strip
       )
       end
     end


### PR DESCRIPTION
Right now if you have in SQL dump constraint checks with regexps for example

```
CREATE TABLE managers (
    id integer NOT NULL,
    email character varying,
    password_digest character varying,
    created_at timestamp without time zone NOT NULL,
    updated_at timestamp without time zone NOT NULL,
    CONSTRAINT email_format CHECK (email ~* '^.+@.+\..+')
);
```

with multiline string `<<-SQL` backslashes will be removed `CHECK (email ~* '^.+@.+..+')`. 

In order to prevent it I used non-interpolated string notation `%q{}`