### PR TITLE
Cleaner: Generate timestamp in UTC timezone

### DIFF
--- a/lib/squasher/cleaner.rb
+++ b/lib/squasher/cleaner.rb
@@ -36,7 +36,7 @@ module Squasher
     end
 
     def now_timestamp
-      Time.now.strftime("%Y%m%d%H%M%S")
+      Time.zone.now.strftime("%Y%m%d%H%M%S")
     end
   end
 end

--- a/lib/squasher/cleaner.rb
+++ b/lib/squasher/cleaner.rb
@@ -36,7 +36,7 @@ module Squasher
     end
 
     def now_timestamp
-      Time.zone.now.strftime("%Y%m%d%H%M%S")
+      Time.now.utc.strftime("%Y%m%d%H%M%S")
     end
   end
 end


### PR DESCRIPTION
I just ran into the following issue: An hour ago I created a migration (`dropResources`). A couple minutes ago, I ran squasher. The squasher clean migration shows up above my `dropResources` migration even though it was run more recently:

![migrations](https://user-images.githubusercontent.com/7606194/48972815-cb30df00-efef-11e8-8023-71ff0d96b282.png)

This is because I'm in US Mountain Time (UTC -0700). Rails generated the migration timestamp as UTC while Squasher generated it in my local timezone.

We can fix this by doing the following: When generating the timestamp for the SquasherClean migration, use `Time.now.utc` rather than `Time.now` to ensure that the timestamp is in UTC time. Rails migrations' timestamps are in UTC (for example, when running `rails g migration CreateUsers`) and Squasher migrations should also be in UTC, so that migrations appear in the correct order.