### PR TITLE
Allow multiverse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- 0.7.0
+  - Support the presence of multiverse ([@mlohbihler](https://github.com/mlohbihler))
 - 0.6.1
   - Escape regexp in sql mode ([@mpospelov](https://github.com/mpospelov))
 - 0.6.0

--- a/bin/squasher
+++ b/bin/squasher
@@ -32,6 +32,10 @@ parser = OptionParser.new do |config|
     options[:engine] = value
   end
 
+  config.on('--databases=DB_KEY,...', 'alternate database configuration keys to be included dbconfig (for multiverse)') do |value|
+    options[:databases] = value&.split(",")
+  end
+
   config.on('-v', '--version', '-h', '--help', 'show this message')
 end
 parser.parse!

--- a/lib/squasher.rb
+++ b/lib/squasher.rb
@@ -46,7 +46,7 @@ module Squasher
   end
 
   def print(message, options = {})
-    puts message % options
+    puts options.empty? ? message : message % options
   end
 
   def error(*args)

--- a/lib/squasher/config.rb
+++ b/lib/squasher/config.rb
@@ -39,6 +39,7 @@ module Squasher
       @root_path = Dir.pwd.freeze
       @migrations_folder = File.join(@root_path, 'db', 'migrate')
       @flags = []
+      @databases = []
       set_app_path(@root_path)
     end
 
@@ -60,6 +61,8 @@ module Squasher
       elsif key == :sql
         @schema_file = File.join(@app_path, 'db', 'structure.sql')
         @flags << key
+      elsif key == :databases
+        @databases = value
       else
         @flags << key
       end
@@ -123,6 +126,7 @@ module Squasher
         content, soft_error = Render.process(dbconfig_file)
         if content.has_key?('development')
           @dbconfig = { 'development' => content['development'].merge('database' => 'squasher') }
+          @databases&.each { |database| @dbconfig[database] = content[database] }
         end
       rescue
       end

--- a/lib/squasher/version.rb
+++ b/lib/squasher/version.rb
@@ -1,3 +1,3 @@
 module Squasher
-  VERSION = "0.6.2"
+  VERSION = "0.7.0"
 end

--- a/spec/fake_app/config/database.yml
+++ b/spec/fake_app/config/database.yml
@@ -16,3 +16,7 @@ another_test:
   database: another_test
   user: root
   password: password
+multiverse-database:
+  database: multiverse-database
+  user: multiverse-user
+  password: multiverse-password

--- a/spec/lib/cleaner_spec.rb
+++ b/spec/lib/cleaner_spec.rb
@@ -5,7 +5,7 @@ describe Squasher::Cleaner do
   let(:expected_file) { File.join(fake_root, 'db', 'migrate', '20140102030405_squasher_clean.rb') }
 
   before do
-    allow(Time).to receive(:now).and_return(Time.new(2014, 1, 2, 3, 4, 5))
+    allow(Time).to receive(:now).and_return(Time.utc(2014, 1, 2, 3, 4, 5))
     allow(Squasher).to receive(:rake).with("db:migrate", :db_cleaning)
   end
 

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -49,6 +49,21 @@ describe Squasher::Config do
       end
     end
 
+    it 'includes other database definitions provided in the command line' do
+      config.set(:databases, ["multiverse-database"])
+      config.stub_dbconfig do
+        File.open(File.join(fake_root, 'config', 'database.yml')) do |stream|
+          content = YAML.load(stream.read)
+          puts "content 2: #{ content }"
+          expect(content["development"]["database"]).to eq("squasher")
+          expect(content["development"]["encoding"]).to eq("utf-8")
+          expect(content["multiverse-database"]["database"]).to eq("multiverse-database")
+          expect(content["multiverse-database"]["user"]).to eq("multiverse-user")
+          expect(content).not_to have_key("another_development")
+        end
+      end
+    end
+
     def file_exists?(*parts)
       File.exists?(File.join(fake_root, *parts))
     end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -54,7 +54,6 @@ describe Squasher::Config do
       config.stub_dbconfig do
         File.open(File.join(fake_root, 'config', 'database.yml')) do |stream|
           content = YAML.load(stream.read)
-          puts "content 2: #{ content }"
           expect(content["development"]["database"]).to eq("squasher")
           expect(content["development"]["encoding"]).to eq("utf-8")
           expect(content["multiverse-database"]["database"]).to eq("multiverse-database")

--- a/spec/lib/squasher_spec.rb
+++ b/spec/lib/squasher_spec.rb
@@ -46,4 +46,12 @@ describe Squasher do
       Squasher.rake('db:migrate')
     end
   end
+
+  context '.print' do
+    context 'when options are empty' do
+      it 'prints the message without error' do
+        Squasher.print('asdf % asdf', {})
+      end
+    end
+  end
 end


### PR DESCRIPTION
As per issue #68, this PR allows multiverse to be present by allowing the user to specify other database keys that should be loaded. There is also a change to Squasher#print that prevents failures due to there being '%' characters in the generated schema (such as in comments).

This PR however does not provide for the squashing of non-default databases.