### PR TITLE
Call ERB.new with correct arguments

### DIFF
--- a/lib/squasher/render.rb
+++ b/lib/squasher/render.rb
@@ -14,7 +14,11 @@ module Squasher
     end
 
     def render
-      ERB.new(template("#{ name }.rb"), nil, '-').result(binding)
+      if RUBY_VERSION < '2.6'
+        ERB.new(template("#{ name }.rb"), nil, '-').result(binding)
+      else
+        ERB.new(template("#{ name }.rb"), trim_mode: '-').result(binding)
+      end
     end
 
     def each_schema_line(&block)


### PR DESCRIPTION
Passing safe_level with the 2nd argument of ERB.new is deprecated and trim_mode with the 3rd argument of ERB.new is deprecated since Ruby 2.6. This PR fixes that.