### PR TITLE
wrap init schema in safety assured to allow for foreign keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+/.idea/

--- a/lib/squasher/templates/init_schema.rb.erb
+++ b/lib/squasher/templates/init_schema.rb.erb
@@ -1,12 +1,18 @@
 class InitSchema < ActiveRecord::Migration<%= @config.migration_version %>
   def up
-<%- each_schema_line do |line| -%>
-<%- next if line.strip.empty?  -%>
-<%= "    #{line}" %>
-<%- end -%>
+    safety_assured { init_schema }
   end
 
   def down
     raise ActiveRecord::IrreversibleMigration, "The initial migration is not revertable"
+  end
+
+  private
+
+  def init_schema
+    <%- each_schema_line do |line| -%>
+    <%- next if line.strip.empty?  -%>
+    <%= "    #{line}" %>
+    <%- end -%>
   end
 end

--- a/lib/squasher/templates/init_schema.rb.erb
+++ b/lib/squasher/templates/init_schema.rb.erb
@@ -1,5 +1,6 @@
 class InitSchema < ActiveRecord::Migration<%= @config.migration_version %>
   def up
+    return init_schema if strong_migrations_missing?
     safety_assured { init_schema }
   end
 
@@ -8,11 +9,15 @@ class InitSchema < ActiveRecord::Migration<%= @config.migration_version %>
   end
 
   private
+    def strong_migrations_missing?
+      gem_dependency = Gem::Dependency.new(StrongMigrations)
+      gem_dependency.matching_specs.first.present?
+    end
 
-  def init_schema
-    <%- each_schema_line do |line| -%>
-    <%- next if line.strip.empty?  -%>
-    <%= "    #{line}" %>
-    <%- end -%>
-  end
+    def init_schema
+      <%- each_schema_line do |line| -%>
+      <%- next if line.strip.empty?  -%>
+      <%= "    #{line}" %>
+      <%- end -%>
+    end
 end

--- a/lib/squasher/templates/init_schema.rb.erb
+++ b/lib/squasher/templates/init_schema.rb.erb
@@ -1,7 +1,10 @@
 class InitSchema < ActiveRecord::Migration<%= @config.migration_version %>
   def up
-    return init_schema if strong_migrations_missing?
-    safety_assured { init_schema }
+    <%- if defined?(StrongMigrations).present? -%> 
+    <%= "    safety_assured { init_schema }" -%>
+    <%- else -%>
+    <%= "    init_schema" -%>
+    <%- end -%>
   end
 
   def down
@@ -9,11 +12,7 @@ class InitSchema < ActiveRecord::Migration<%= @config.migration_version %>
   end
 
   private
-    def strong_migrations_missing?
-      gem_dependency = Gem::Dependency.new(StrongMigrations)
-      gem_dependency.matching_specs.first.present?
-    end
-
+    
     def init_schema
       <%- each_schema_line do |line| -%>
       <%- next if line.strip.empty?  -%>


### PR DESCRIPTION
Use safety_assured in init_schema if [strongmigrations](https://github.com/ankane/strong_migrations) are in use so that foreign keys can still be applied.