### PR TITLE
Add support for Rails-style multiple dbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- 0.8.0
+  - Support multiple databases in Rails-style ([@fynsta](https://github.com/fynsta))
 - 0.7.0
   - Support the presence of multiverse ([@mlohbihler](https://github.com/mlohbihler))
 - 0.6.1

--- a/bin/squasher
+++ b/bin/squasher
@@ -32,7 +32,11 @@ parser = OptionParser.new do |config|
     options[:engine] = value
   end
 
-  config.on('--databases=DB_KEY,...', 'alternate database configuration keys to be included dbconfig (for multiverse)') do |value|
+  config.on('--multi-db_format=FORMAT', 'format of the multi-db configuration (rails, multiverse)') do |value|
+    options[:multi_db_format] = value
+  end
+
+  config.on('--databases=DB_KEY,...', 'alternate database configuration keys to be included') do |value|
     options[:databases] = value&.split(",")
   end
 

--- a/lib/squasher/cleaner.rb
+++ b/lib/squasher/cleaner.rb
@@ -26,7 +26,7 @@ module Squasher
         FileUtils.rm(prev_migration)
       end
       File.open(migration_file, 'wb') do |stream|
-        stream << ::Squasher::Render.render(MIGRATION_NAME, config)
+        stream << ::Squasher::Render.render(MIGRATION_NAME, config, database)
       end
 
       if database.nil?

--- a/lib/squasher/cleaner.rb
+++ b/lib/squasher/cleaner.rb
@@ -9,16 +9,31 @@ module Squasher
     end
 
     def process
-      Squasher.error(:migration_folder_missing) unless config.migrations_folder?
+      Squasher.error(:migration_folder_missing) unless config.migrations_folders?
 
-      migration_file = config.migration_file(now_timestamp, MIGRATION_NAME)
-      if prev_migration
+      if config.multi_db_format == 'rails'
+        config.databases.each do |database|
+          process_database(database)
+        end
+      else
+        process_database
+      end
+    end
+
+    def process_database(database = nil)
+      migration_file = config.migration_file(now_timestamp, MIGRATION_NAME, database)
+      if (prev_migration = prev_migration(database))
         FileUtils.rm(prev_migration)
       end
       File.open(migration_file, 'wb') do |stream|
         stream << ::Squasher::Render.render(MIGRATION_NAME, config)
       end
-      Squasher.rake("db:migrate", :db_cleaning)
+
+      if database.nil?
+        Squasher.rake("db:migrate", :db_cleaning)
+      else
+        Squasher.rake("db:migrate:#{database}", :db_cleaning)
+      end
     end
 
     private
@@ -27,10 +42,10 @@ module Squasher
       Squasher.config
     end
 
-    def prev_migration
+    def prev_migration(database = nil)
       return @prev_migration if defined?(@prev_migration)
 
-      @prev_migration = config.migration_files.detect do |file|
+      @prev_migration = config.migration_files(database).detect do |file|
         File.basename(file).include?(MIGRATION_NAME)
       end
     end

--- a/lib/squasher/config.rb
+++ b/lib/squasher/config.rb
@@ -34,12 +34,12 @@ module Squasher
       end
     end
 
-    attr_reader :schema_file, :migration_version
+    attr_reader :schema_file, :migration_version, :multi_db_format, :databases
 
     def initialize
       @root_path = Dir.pwd.freeze
-      @migrations_folder = File.join(@root_path, 'db', 'migrate')
       @flags = []
+      @multi_db_format = nil
       @databases = []
       set_app_path(@root_path)
     end
@@ -62,6 +62,9 @@ module Squasher
       elsif key == :sql
         @schema_file = File.join(@app_path, 'db', 'structure.sql')
         @flags << key
+      elsif key == :multi_db_format
+        Squasher.error(:invalid_multi_db_format, value: value) unless %w[rails multiverse].include?(value)
+        @multi_db_format = value
       elsif key == :databases
         @databases = value
       else
@@ -73,16 +76,33 @@ module Squasher
       @flags.include?(k)
     end
 
-    def migration_files
-      Dir.glob(File.join(migrations_folder, '**.rb'))
+    def migration_files(database = nil)
+      Dir.glob(File.join(migrations_folder(database), '**.rb'))
     end
 
-    def migration_file(timestamp, migration_name)
-      File.join(migrations_folder, "#{ timestamp }_#{ migration_name }.rb")
+    def migration_file(timestamp, migration_name, database = nil)
+      File.join(migrations_folder(database), "#{ timestamp }_#{ migration_name }.rb")
     end
 
-    def migrations_folder?
-      Dir.exist?(migrations_folder)
+    def migrations_folder(database = nil)
+      return default_migration_folder if database.nil?
+
+      migrations_paths = dbconfig['development'][database]['migrations_paths']
+      return default_migration_folder unless migrations_paths
+
+      File.join(@app_path, migrations_paths)
+    end
+
+    def migrations_folders?
+      if @multi_db_format != 'rails'
+        Dir.exist?(migrations_folder)
+      else
+        @databases.all? { |db| Dir.exist?(migrations_folder(db)) }
+      end
+    end
+
+    def default_migration_folder
+      File.join(@root_path, 'db', 'migrate')
     end
 
     def dbconfig?
@@ -115,7 +135,7 @@ module Squasher
 
     private
 
-    attr_reader :migrations_folder, :dbconfig_file
+    attr_reader :dbconfig_file
 
     def dbconfig
       return @dbconfig if defined?(@dbconfig)
@@ -126,8 +146,27 @@ module Squasher
       begin
         content, soft_error = Render.process(dbconfig_file)
         if content.has_key?('development')
-          @dbconfig = { 'development' => content['development'].merge('database' => 'squasher') }
-          @databases&.each { |database| @dbconfig[database] = content[database] }
+          if @multi_db_format == 'rails'
+            @dbconfig = { 'development' => {} }
+            @databases.each do |database|
+              @dbconfig['development'][database] = content['development'][database].merge('database' => "#{database}_squasher")
+              
+              database_name = content['development'][database]['database']
+              content['development'].select { |_, v| v['database'] == database_name && v['replica'] }.each do |k, v|
+                @dbconfig['development'][k] = v.merge('database' => "#{database}_squasher")
+              end
+            end
+          else
+            @dbconfig = { 'development' => content['development'].merge('database' => 'squasher') }
+
+            multiverse_by_default = @multi_db_format.nil? && @databases.any?
+            if multiverse_by_default
+              puts "Using multiverse format by default is deprecated and will be removed in the next major release. Please specify --multi-db_format=rails or --multi-db_format=multiverse explicitly."
+            end
+            if multiverse_by_default || @multi_db_format == 'multiverse'
+              @databases&.each { |database| @dbconfig[database] = content[database] }
+            end
+          end
         end
       rescue
       end

--- a/lib/squasher/render.rb
+++ b/lib/squasher/render.rb
@@ -8,9 +8,10 @@ module Squasher
 
     attr_reader :name, :config
 
-    def initialize(name, config)
+    def initialize(name, config, database = nil)
       @name = name
       @config = config
+      @database = database
     end
 
     def render
@@ -22,7 +23,7 @@ module Squasher
     end
 
     def each_schema_line(&block)
-      File.open(config.schema_file, 'r') do |stream|
+      File.open(config.schema_file(@database), 'r') do |stream|
         if @config.set?(:sql)
           stream_structure(stream, &block)
         else

--- a/lib/squasher/worker.rb
+++ b/lib/squasher/worker.rb
@@ -72,8 +72,8 @@ module Squasher
 
     def clean_migrations(database = nil)
       path = config.migration_file(finish_timestamp(database), :init_schema, database)
-      File.open(path, 'wb') { |io| io << Render.render(:init_schema, config) }
-      migrations(database).each { |file| FileUtils.rm(file) }
+      migrations(database).each { |file| FileUtils.rm(file) } # Remove all migrations before creating the new one
+      File.open(path, 'wb') { |io| io << Render.render(:init_schema, config, database) }
     end
 
     def before_date?(timestamp)

--- a/lib/squasher/worker.rb
+++ b/lib/squasher/worker.rb
@@ -20,9 +20,13 @@ module Squasher
           Squasher.tell(:dry_mode_finished)
           Squasher.print(Render.render(:init_schema, config))
         else
-          path = config.migration_file(finish_timestamp, :init_schema)
-          File.open(path, 'wb') { |io| io << Render.render(:init_schema, config) }
-          migrations.each { |file| FileUtils.rm(file) }
+          if config.multi_db_format == 'rails'
+            config.databases.each do |database|
+              clean_migrations(database)
+            end
+          else
+            clean_migrations
+          end
         end
 
         Squasher.rake("db:drop") unless Squasher.ask(:keep_database)
@@ -38,20 +42,38 @@ module Squasher
     end
 
     def check!
-      Squasher.error(:migration_folder_missing) unless config.migrations_folder?
+      Squasher.error(:migration_folder_missing) unless config.migrations_folders?
       Squasher.error(:dbconfig_invalid) unless config.dbconfig?
-      if migrations.empty?
-        print_date = date.strftime("%Y/%m/%d")
-        Squasher.error(:no_migrations, :date => print_date)
+
+      if config.multi_db_format == 'rails'
+        config.databases.each do |database|
+          check_migrations_exist(database)
+        end
+      else
+        check_migrations_exist
       end
     end
 
-    def migrations
-      @migrations ||= config.migration_files.select { |file| before_date?(get_timestamp(file)) }.sort
+    def check_migrations_exist(database = nil)
+      if migrations(database).empty?
+        print_date = date.strftime("%Y/%m/%d")
+
+        Squasher.error(:no_migrations, :date => date.strftime("%Y/%m/%d"))
+      end
+    end
+
+    def migrations(database = nil)
+      config.migration_files(database).select { |file| before_date?(get_timestamp(file)) }.sort
     end
 
     def get_timestamp(file)
       File.basename(file)[/\A\d+/]
+    end
+
+    def clean_migrations(database = nil)
+      path = config.migration_file(finish_timestamp(database), :init_schema, database)
+      File.open(path, 'wb') { |io| io << Render.render(:init_schema, config) }
+      migrations(database).each { |file| FileUtils.rm(file) }
     end
 
     def before_date?(timestamp)
@@ -60,8 +82,8 @@ module Squasher
       timestamp[0...8].to_i < @point
     end
 
-    def finish_timestamp
-      @finish_timestamp ||= get_timestamp(migrations.last)
+    def finish_timestamp(database = nil)
+      get_timestamp(migrations(database).last)
     end
 
     def under_squash_env
@@ -72,7 +94,13 @@ module Squasher
           return unless Squasher.rake("db:drop db:create", :db_create)
         end
 
-        return unless Squasher.rake("db:migrate VERSION=#{ finish_timestamp }", :db_migrate)
+        if config.multi_db_format == 'rails'
+          config.databases.each do |database|
+            return unless Squasher.rake("db:migrate:#{ database } VERSION=#{ finish_timestamp(database) }", :db_migrate)
+          end
+        else
+          return unless Squasher.rake("db:migrate VERSION=#{ finish_timestamp }", :db_migrate)
+        end
 
         yield
 

--- a/spec/lib/worker_spec.rb
+++ b/spec/lib/worker_spec.rb
@@ -6,7 +6,7 @@ describe Squasher::Worker do
     let(:worker) { described_class.new(Time.new(2012, 6, 20)) }
 
     specify 'command was run not in application root' do
-      allow_any_instance_of(Squasher::Config).to receive(:migrations_folder?).and_return(false)
+      allow_any_instance_of(Squasher::Config).to receive(:migrations_folders?).and_return(false)
 
       expect_exit_with(:migration_folder_missing)
     end
@@ -31,7 +31,7 @@ describe Squasher::Worker do
     worker = described_class.new(Time.new(2014))
     allow(worker).to receive(:under_squash_env).and_yield.and_return(true)
     new_migration_path = File.join(Dir.tmpdir, 'init_schema.rb')
-    allow_any_instance_of(Squasher::Config).to receive(:migration_file).with('20131213090719', :init_schema).and_return(new_migration_path)
+    allow_any_instance_of(Squasher::Config).to receive(:migration_file).with('20131213090719', :init_schema, nil).and_return(new_migration_path)
 
     expect(FileUtils).to receive(:rm).with(File.join(fake_root, 'db', 'migrate', '20131205160936_first_migration.rb'))
     expect(FileUtils).to receive(:rm).with(File.join(fake_root, 'db', 'migrate', '20131213090719_second_migration.rb'))
@@ -60,7 +60,7 @@ describe Squasher::Worker do
       worker = described_class.new(Time.new(2014))
       allow(worker).to receive(:under_squash_env).and_yield.and_return(true)
       new_migration_path = File.join(Dir.tmpdir, 'init_schema.rb')
-      allow_any_instance_of(Squasher::Config).to receive(:migration_file).with('20131213090719', :init_schema).and_return(new_migration_path)
+      allow_any_instance_of(Squasher::Config).to receive(:migration_file).with('20131213090719', :init_schema, nil).and_return(new_migration_path)
       expect(FileUtils).to receive(:rm).with(File.join(fake_root, 'db', 'migrate', '20131205160936_first_migration.rb'))
       expect(FileUtils).to receive(:rm).with(File.join(fake_root, 'db', 'migrate', '20131213090719_second_migration.rb'))
 


### PR DESCRIPTION
This commit adds support for multiple databases in `Active Record`-style (https://guides.rubyonrails.org/active_record_multiple_databases.html). I tried to maintain backwards-compatibility (keeping `multiverse` as the default if `databases` are given, but this should surely be changed in the future.

Let me know if this approach makes sense to you. I will write tests if this feature is desired. It works locally for me.