### PR TITLE
squasher.gemspec: use long description on Rubygems.org, to clarify

### DIFF
--- a/squasher.gemspec
+++ b/squasher.gemspec
@@ -8,7 +8,14 @@ Gem::Specification.new do |spec|
   spec.version       = Squasher::VERSION
   spec.authors       = ["Sergey Pchelintsev"]
   spec.email         = ["linz.sergey@gmail.com"]
-  spec.description   = %q{Squash your old migrations}
+  spec.description   = <<-DESCRIPTION.chomp.gsub("\n", " ")
+Squasher compresses old ActiveRecord migrations. On a big project with
+many migrations, every rake db:migrate might take a few seconds, or creating
+of a new database might take a few minutes. That's because ActiveRecord loads
+all those migration files. Squasher removes all the migrations and creates a
+single migration with the final database state of the specified date.
+The new migration will look like a schema.rb file.
+DESCRIPTION
   spec.summary       = %q{Squash your old migrations}
   spec.homepage      = "https://github.com/jalkoby/squasher"
   spec.license       = "MIT"


### PR DESCRIPTION
Being able to learn on Rubygems.org what a gem does is... good?